### PR TITLE
Added GCS connector to dockerfile

### DIFF
--- a/vm-docker/Dockerfile
+++ b/vm-docker/Dockerfile
@@ -124,6 +124,16 @@ RUN python3 -m pip install \
     pybedtools \
     dill
 
+# Install GCS Connector
+RUN export SPARK_HOME=$(find_spark_home.py) && \
+    curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
+         >$SPARK_HOME/jars/gcs-connector-hadoop2-2.0.1.jar && \
+    mkdir -p $SPARK_HOME/conf && \
+    touch $SPARK_HOME/conf/spark-defaults.conf && \
+    sed -i $SPARK_HOME/conf/spark-defaults.conf \
+        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true:' \
+        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'
+
 # Install R
 ENV R_VERSION="3.5.2-1"
 RUN apt-get install -y \


### PR DESCRIPTION
Added so that this image can be used for batch PythonJobs in the future. Code is from Daniel Goldstein: https://hail.zulipchat.com/#narrow/stream/223457-Batch-support/topic/Amount.20of.20time.20to.20submit.20PythonJob/near/243555018

An alternate workaround is to add something like the following to the PythonJob:
```
j = b.new_python_job(name=sample)

# Install GCS Connector
def _install_gcs():
    os.system("gcloud -q auth activate-service-account --key-file=/gsa-key/key.json")
    os.system("curl -sSL https://broad.io/install-gcs-connector | python3")
 j.call(_install_gcs)
j.call(<actual job command here>)
```